### PR TITLE
Fix manga card links

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -15,22 +15,21 @@ fetch('data/mangas.json')
     function render(lista) {
       container.innerHTML = '';
       lista.forEach(m => {
-        const link = `manga/${slugify(m.nome)}.html`;
+        const cardLink = document.createElement('a');
+        cardLink.href = `manga/${slugify(m.nome)}.html`;
+        cardLink.className = 'manga-card';
+        cardLink.style.textDecoration = 'none';
+        cardLink.style.color = 'inherit';
 
-        const card = document.createElement('div');
-        card.className = 'manga-card';
-
-        card.innerHTML = `
-          <a href="${link}" style="text-decoration: none; color: inherit;">
-            <img src="assets/capas/${m.imagem}" alt="${m.nome}" />
-            <h3>${m.nome}</h3>
-            <p><strong>Volumes:</strong> ${m.volumes}</p>
-            <p><strong>Autor:</strong> ${m.autor}</p>
-            <p><strong>Status:</strong> ${m.status}</p>
-          </a>
+        cardLink.innerHTML = `
+          <img src="assets/capas/${m.imagem}" alt="${m.nome}" />
+          <h3>${m.nome}</h3>
+          <p><strong>Volumes:</strong> ${m.volumes}</p>
+          <p><strong>Autor:</strong> ${m.autor}</p>
+          <p><strong>Status:</strong> ${m.status}</p>
         `;
 
-        container.appendChild(card);
+        container.appendChild(cardLink);
       });
     }
 

--- a/style/style.css
+++ b/style/style.css
@@ -27,6 +27,7 @@ h1 {
 }
 
 .manga-card {
+  display: block;
   background-color: white;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- make entire manga card an `<a>` element so clicking goes to the generated page
- ensure the anchor element fills the card with CSS `display: block`

## Testing
- `node scripts/gerarHtml.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882818ae9408322a9f4299f7e372bff